### PR TITLE
Fix wrong base url detection for /wp-admin/ /wp-login.php

### DIFF
--- a/src/WpStarter/Http/Request.php
+++ b/src/WpStarter/Http/Request.php
@@ -164,8 +164,28 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
     public function path()
     {
         $pattern = trim($this->getPathInfo(), '/');
-
         return $pattern === '' ? '/' : $pattern;
+    }
+    protected function prepareBaseUrl()
+    {
+        $serverVars=[];
+        $serverVars['SCRIPT_FILENAME']=$this->server->get('SCRIPT_FILENAME', '');
+        $serverVars['SCRIPT_NAME']=$this->server->get('SCRIPT_NAME', '');
+        $serverVars['PHP_SELF']=$this->server->get('PHP_SELF', '');
+        $serverVars['ORIG_SCRIPT_NAME']=$this->server->get('ORIG_SCRIPT_NAME', '');
+        $changed=[];
+        foreach ($serverVars as $key=>$value){
+            if($filename = basename($value)){
+                $changed[]=$key;
+                $newValue=str_replace([$filename,'/wp-admin/'],['index.php','/'],$value);
+                $this->server->set($key,$newValue);
+            }
+        }
+        $baseUrl=parent::prepareBaseUrl();
+        foreach ($changed as $key){
+            $this->server->set($key,$serverVars[$key]);
+        }
+        return  $baseUrl;
     }
 
     /**


### PR DESCRIPTION
Path and url are in correct for requests which not run through main WordPress's index.php like /wp-login.php, /wp-admin/, /wp-admin/edit.php,...