### PR TITLE
Fix deprecated notice

### DIFF
--- a/src/WpStarter/Http/Concerns/InteractsWithInput.php
+++ b/src/WpStarter/Http/Concerns/InteractsWithInput.php
@@ -7,6 +7,7 @@ use WpStarter\Support\Arr;
 use WpStarter\Support\Facades\Date;
 use SplFileInfo;
 use stdClass;
+use Symfony\Component\HttpFoundation\InputBag;
 use Symfony\Component\VarDumper\VarDumper;
 
 trait InteractsWithInput
@@ -505,6 +506,10 @@ trait InteractsWithInput
     {
         if (is_null($key)) {
             return $this->$source->all();
+        }
+
+        if ($this->$source instanceof InputBag) {
+            return $this->$source->all()[$key] ?? $default;
         }
 
         return $this->$source->get($key, $default);

--- a/src/WpStarter/Wordpress/Application.php
+++ b/src/WpStarter/Wordpress/Application.php
@@ -11,7 +11,7 @@ class Application extends \WpStarter\Foundation\Application
      *
      * @var string
      */
-    const VERSION = '1.9.3';
+    const VERSION = '1.9.4';
 
     protected $bootstrappedList = [];
 


### PR DESCRIPTION
Since symfony/http-foundation 5.1: Retrieving a non-scalar value from "Symfony\Component\HttpFoundation\InputBag::get()" is deprecated, and will throw a "Symfony\Component\HttpFoundation\Exception\BadRequestException" exception in Symfony 6.0, use "Symfony\Component\HttpFoundation\InputBag::all($key)" instead.