### PR TITLE
fix: add missing nullable types for PHP 8.4 compatibility

### DIFF
--- a/src/WpStarter/Auth/Access/AuthorizationException.php
+++ b/src/WpStarter/Auth/Access/AuthorizationException.php
@@ -22,7 +22,7 @@ class AuthorizationException extends Exception
      * @param  \Throwable|null  $previous
      * @return void
      */
-    public function __construct($message = null, $code = null, Throwable $previous = null)
+    public function __construct($message = null, $code = null, ?Throwable $previous = null)
     {
         parent::__construct($message ?? 'This action is unauthorized.', 0, $previous);
 

--- a/src/WpStarter/Auth/Access/Gate.php
+++ b/src/WpStarter/Auth/Access/Gate.php
@@ -88,7 +88,7 @@ class Gate implements GateContract
      */
     public function __construct(Container $container, callable $userResolver, array $abilities = [],
                                 array $policies = [], array $beforeCallbacks = [], array $afterCallbacks = [],
-                                callable $guessPolicyNamesUsingCallback = null)
+                                ?callable $guessPolicyNamesUsingCallback = null)
     {
         $this->policies = $policies;
         $this->container = $container;
@@ -212,7 +212,7 @@ class Gate implements GateContract
      * @param  array|null  $abilities
      * @return $this
      */
-    public function resource($name, $class, array $abilities = null)
+    public function resource($name, $class, ?array $abilities = null)
     {
         $abilities = $abilities ?: [
             'viewAny' => 'viewAny',

--- a/src/WpStarter/Auth/Passwords/PasswordBroker.php
+++ b/src/WpStarter/Auth/Passwords/PasswordBroker.php
@@ -45,7 +45,7 @@ class PasswordBroker implements PasswordBrokerContract
      * @param  \Closure|null  $callback
      * @return string
      */
-    public function sendResetLink(array $credentials, Closure $callback = null)
+    public function sendResetLink(array $credentials, ?Closure $callback = null)
     {
         // First we will check to see if we found a user at the given credentials and
         // if we did not we will redirect back to this current URI with a piece of

--- a/src/WpStarter/Auth/RequestGuard.php
+++ b/src/WpStarter/Auth/RequestGuard.php
@@ -33,7 +33,7 @@ class RequestGuard implements Guard
      * @param  \WpStarter\Contracts\Auth\UserProvider|null  $provider
      * @return void
      */
-    public function __construct(callable $callback, Request $request, UserProvider $provider = null)
+    public function __construct(callable $callback, Request $request, ?UserProvider $provider = null)
     {
         $this->request = $request;
         $this->callback = $callback;

--- a/src/WpStarter/Auth/SessionGuard.php
+++ b/src/WpStarter/Auth/SessionGuard.php
@@ -123,8 +123,8 @@ class SessionGuard implements StatefulGuard, SupportsBasicAuth
     public function __construct($name,
                                 UserProvider $provider,
                                 Session $session,
-                                Request $request = null,
-                                Timebox $timebox = null)
+                                ?Request $request = null,
+                                ?Timebox $timebox = null)
     {
         $this->name = $name;
         $this->session = $session;

--- a/src/WpStarter/Broadcasting/BroadcastManager.php
+++ b/src/WpStarter/Broadcasting/BroadcastManager.php
@@ -60,7 +60,7 @@ class BroadcastManager implements FactoryContract
      * @param  array|null  $attributes
      * @return void
      */
-    public function routes(array $attributes = null)
+    public function routes(?array $attributes = null)
     {
         if ($this->app instanceof CachesRoutes && $this->app->routesAreCached()) {
             return;

--- a/src/WpStarter/Bus/Batch.php
+++ b/src/WpStarter/Bus/Batch.php
@@ -424,7 +424,7 @@ class Batch implements Arrayable, JsonSerializable
      * @param  \Throwable|null  $e
      * @return void
      */
-    protected function invokeHandlerCallback($handler, Batch $batch, Throwable $e = null)
+    protected function invokeHandlerCallback($handler, Batch $batch, ?Throwable $e = null)
     {
         try {
             return $handler($batch, $e);

--- a/src/WpStarter/Bus/Dispatcher.php
+++ b/src/WpStarter/Bus/Dispatcher.php
@@ -58,7 +58,7 @@ class Dispatcher implements QueueingDispatcher
      * @param  \Closure|null  $queueResolver
      * @return void
      */
-    public function __construct(Container $container, Closure $queueResolver = null)
+    public function __construct(Container $container, ?Closure $queueResolver = null)
     {
         $this->container = $container;
         $this->queueResolver = $queueResolver;

--- a/src/WpStarter/Collections/Arr.php
+++ b/src/WpStarter/Collections/Arr.php
@@ -180,7 +180,7 @@ class Arr
      * @param  mixed  $default
      * @return mixed
      */
-    public static function first($array, callable $callback = null, $default = null)
+    public static function first($array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
             if (empty($array)) {
@@ -209,7 +209,7 @@ class Arr
      * @param  mixed  $default
      * @return mixed
      */
-    public static function last($array, callable $callback = null, $default = null)
+    public static function last($array, ?callable $callback = null, $default = null)
     {
         if (is_null($callback)) {
             return empty($array) ? ws_value($default) : end($array);

--- a/src/WpStarter/Collections/Collection.php
+++ b/src/WpStarter/Collections/Collection.php
@@ -352,7 +352,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  callable|null  $callback
      * @return static
      */
-    public function filter(callable $callback = null)
+    public function filter(?callable $callback = null)
     {
         if ($callback) {
             return new static(Arr::where($this->items, $callback));
@@ -368,7 +368,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  mixed  $default
      * @return mixed
      */
-    public function first(callable $callback = null, $default = null)
+    public function first(?callable $callback = null, $default = null)
     {
         return Arr::first($this->items, $callback, $default);
     }
@@ -665,7 +665,7 @@ class Collection implements ArrayAccess, CanBeEscapedWhenCastToString, Enumerabl
      * @param  mixed  $default
      * @return mixed
      */
-    public function last(callable $callback = null, $default = null)
+    public function last(?callable $callback = null, $default = null)
     {
         return Arr::last($this->items, $callback, $default);
     }

--- a/src/WpStarter/Collections/Enumerable.php
+++ b/src/WpStarter/Collections/Enumerable.php
@@ -25,7 +25,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  callable|null  $callback
      * @return static
      */
-    public static function times($number, callable $callback = null);
+    public static function times($number, ?callable $callback = null);
 
     /**
      * Create a collection with the given range.
@@ -265,7 +265,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  callable|null  $callback
      * @return static
      */
-    public function filter(callable $callback = null);
+    public function filter(?callable $callback = null);
 
     /**
      * Apply the callback if the value is truthy.
@@ -275,7 +275,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function when($value, callable $callback, callable $default = null);
+    public function when($value, callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback if the collection is empty.
@@ -284,7 +284,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function whenEmpty(callable $callback, callable $default = null);
+    public function whenEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback if the collection is not empty.
@@ -293,7 +293,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function whenNotEmpty(callable $callback, callable $default = null);
+    public function whenNotEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback if the value is falsy.
@@ -303,7 +303,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function unless($value, callable $callback, callable $default = null);
+    public function unless($value, callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback unless the collection is empty.
@@ -312,7 +312,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function unlessEmpty(callable $callback, callable $default = null);
+    public function unlessEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Apply the callback unless the collection is not empty.
@@ -321,7 +321,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function unlessNotEmpty(callable $callback, callable $default = null);
+    public function unlessNotEmpty(callable $callback, ?callable $default = null);
 
     /**
      * Filter items by the given key value pair.
@@ -429,7 +429,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  mixed  $default
      * @return mixed
      */
-    public function first(callable $callback = null, $default = null);
+    public function first(?callable $callback = null, $default = null);
 
     /**
      * Get the first item by the given key value pair.
@@ -552,7 +552,7 @@ interface Enumerable extends Arrayable, Countable, IteratorAggregate, Jsonable, 
      * @param  mixed  $default
      * @return mixed
      */
-    public function last(callable $callback = null, $default = null);
+    public function last(?callable $callback = null, $default = null);
 
     /**
      * Run a map over each of the items.

--- a/src/WpStarter/Collections/LazyCollection.php
+++ b/src/WpStarter/Collections/LazyCollection.php
@@ -367,7 +367,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  callable|null  $callback
      * @return static
      */
-    public function filter(callable $callback = null)
+    public function filter(?callable $callback = null)
     {
         if (is_null($callback)) {
             $callback = function ($value) {
@@ -391,7 +391,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  mixed  $default
      * @return mixed
      */
-    public function first(callable $callback = null, $default = null)
+    public function first(?callable $callback = null, $default = null)
     {
         $iterator = $this->getIterator();
 
@@ -632,7 +632,7 @@ class LazyCollection implements CanBeEscapedWhenCastToString, Enumerable
      * @param  mixed  $default
      * @return mixed
      */
-    public function last(callable $callback = null, $default = null)
+    public function last(?callable $callback = null, $default = null)
     {
         $needle = $placeholder = new stdClass;
 

--- a/src/WpStarter/Collections/Traits/EnumeratesValues.php
+++ b/src/WpStarter/Collections/Traits/EnumeratesValues.php
@@ -141,7 +141,7 @@ trait EnumeratesValues
      * @param  callable|null  $callback
      * @return static
      */
-    public static function times($number, callable $callback = null)
+    public static function times($number, ?callable $callback = null)
     {
         if ($number < 1) {
             return new static;
@@ -472,7 +472,7 @@ trait EnumeratesValues
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function when($value, callable $callback = null, callable $default = null)
+    public function when($value, ?callable $callback = null, ?callable $default = null)
     {
         if (! $callback) {
             return new HigherOrderWhenProxy($this, $value);
@@ -494,7 +494,7 @@ trait EnumeratesValues
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function whenEmpty(callable $callback, callable $default = null)
+    public function whenEmpty(callable $callback, ?callable $default = null)
     {
         return $this->when($this->isEmpty(), $callback, $default);
     }
@@ -506,7 +506,7 @@ trait EnumeratesValues
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function whenNotEmpty(callable $callback, callable $default = null)
+    public function whenNotEmpty(callable $callback, ?callable $default = null)
     {
         return $this->when($this->isNotEmpty(), $callback, $default);
     }
@@ -519,7 +519,7 @@ trait EnumeratesValues
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function unless($value, callable $callback, callable $default = null)
+    public function unless($value, callable $callback, ?callable $default = null)
     {
         return $this->when(! $value, $callback, $default);
     }
@@ -531,7 +531,7 @@ trait EnumeratesValues
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function unlessEmpty(callable $callback, callable $default = null)
+    public function unlessEmpty(callable $callback, ?callable $default = null)
     {
         return $this->whenNotEmpty($callback, $default);
     }
@@ -543,7 +543,7 @@ trait EnumeratesValues
      * @param  callable|null  $default
      * @return static|mixed
      */
-    public function unlessNotEmpty(callable $callback, callable $default = null)
+    public function unlessNotEmpty(callable $callback, ?callable $default = null)
     {
         return $this->whenEmpty($callback, $default);
     }

--- a/src/WpStarter/Console/Application.php
+++ b/src/WpStarter/Console/Application.php
@@ -79,7 +79,7 @@ class Application extends SymfonyApplication implements ApplicationContract
      *
      * @return int
      */
-    public function run(InputInterface $input = null, OutputInterface $output = null)
+    public function run(?InputInterface $input = null, ?OutputInterface $output = null)
     {
         $commandName = $this->getCommandName(
             $input = $input ?: new ArgvInput

--- a/src/WpStarter/Container/Container.php
+++ b/src/WpStarter/Container/Container.php
@@ -1111,7 +1111,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function beforeResolving($abstract, Closure $callback = null)
+    public function beforeResolving($abstract, ?Closure $callback = null)
     {
         if (is_string($abstract)) {
             $abstract = $this->getAlias($abstract);
@@ -1131,7 +1131,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function resolving($abstract, Closure $callback = null)
+    public function resolving($abstract, ?Closure $callback = null)
     {
         if (is_string($abstract)) {
             $abstract = $this->getAlias($abstract);
@@ -1151,7 +1151,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function afterResolving($abstract, Closure $callback = null)
+    public function afterResolving($abstract, ?Closure $callback = null)
     {
         if (is_string($abstract)) {
             $abstract = $this->getAlias($abstract);
@@ -1390,7 +1390,7 @@ class Container implements ArrayAccess, ContainerContract
      * @param  \WpStarter\Contracts\Container\Container|null  $container
      * @return \WpStarter\Contracts\Container\Container|static
      */
-    public static function setInstance(ContainerContract $container = null)
+    public static function setInstance(?ContainerContract $container = null)
     {
         return static::$instance = $container;
     }

--- a/src/WpStarter/Contracts/Auth/Access/Gate.php
+++ b/src/WpStarter/Contracts/Auth/Access/Gate.php
@@ -29,7 +29,7 @@ interface Gate
      * @param  array|null  $abilities
      * @return $this
      */
-    public function resource($name, $class, array $abilities = null);
+    public function resource($name, $class, ?array $abilities = null);
 
     /**
      * Define a policy class for a given class type.

--- a/src/WpStarter/Contracts/Auth/PasswordBroker.php
+++ b/src/WpStarter/Contracts/Auth/PasswordBroker.php
@@ -48,7 +48,7 @@ interface PasswordBroker
      * @param  \Closure|null  $callback
      * @return string
      */
-    public function sendResetLink(array $credentials, Closure $callback = null);
+    public function sendResetLink(array $credentials, ?Closure $callback = null);
 
     /**
      * Reset the password for the given token.

--- a/src/WpStarter/Contracts/Container/Container.php
+++ b/src/WpStarter/Contracts/Container/Container.php
@@ -170,7 +170,7 @@ interface Container extends ContainerInterface
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function resolving($abstract, Closure $callback = null);
+    public function resolving($abstract, ?Closure $callback = null);
 
     /**
      * Register a new after resolving callback.
@@ -179,5 +179,5 @@ interface Container extends ContainerInterface
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function afterResolving($abstract, Closure $callback = null);
+    public function afterResolving($abstract, ?Closure $callback = null);
 }

--- a/src/WpStarter/Database/Capsule/Manager.php
+++ b/src/WpStarter/Database/Capsule/Manager.php
@@ -27,7 +27,7 @@ class Manager
      * @param  \WpStarter\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->setupContainer($container ?: new Container);
 

--- a/src/WpStarter/Database/Eloquent/Builder.php
+++ b/src/WpStarter/Database/Eloquent/Builder.php
@@ -191,7 +191,7 @@ class Builder
      * @param  array|null  $scopes
      * @return $this
      */
-    public function withoutGlobalScopes(array $scopes = null)
+    public function withoutGlobalScopes(?array $scopes = null)
     {
         if (! is_array($scopes)) {
             $scopes = array_keys($this->scopes);
@@ -536,7 +536,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Eloquent\Model|static|mixed
      */
-    public function firstOr($columns = ['*'], Closure $callback = null)
+    public function firstOr($columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;

--- a/src/WpStarter/Database/Eloquent/Casts/Attribute.php
+++ b/src/WpStarter/Database/Eloquent/Casts/Attribute.php
@@ -32,7 +32,7 @@ class Attribute
      * @param  callable|null  $set
      * @return void
      */
-    public function __construct(callable $get = null, callable $set = null)
+    public function __construct(?callable $get = null, ?callable $set = null)
     {
         $this->get = $get;
         $this->set = $set;

--- a/src/WpStarter/Database/Eloquent/Concerns/HasGlobalScopes.php
+++ b/src/WpStarter/Database/Eloquent/Concerns/HasGlobalScopes.php
@@ -18,7 +18,7 @@ trait HasGlobalScopes
      *
      * @throws \InvalidArgumentException
      */
-    public static function addGlobalScope($scope, Closure $implementation = null)
+    public static function addGlobalScope($scope, ?Closure $implementation = null)
     {
         if (is_string($scope) && ! is_null($implementation)) {
             return static::$globalScopes[static::class][$scope] = $implementation;

--- a/src/WpStarter/Database/Eloquent/Concerns/QueriesRelationships.php
+++ b/src/WpStarter/Database/Eloquent/Concerns/QueriesRelationships.php
@@ -27,7 +27,7 @@ trait QueriesRelationships
      *
      * @throws \RuntimeException
      */
-    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
     {
         if (is_string($relation)) {
             if (strpos($relation, '.') !== false) {
@@ -120,7 +120,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function doesntHave($relation, $boolean = 'and', Closure $callback = null)
+    public function doesntHave($relation, $boolean = 'and', ?Closure $callback = null)
     {
         return $this->has($relation, '<', 1, $boolean, $callback);
     }
@@ -145,7 +145,7 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }
@@ -159,7 +159,7 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function orWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'or', $callback);
     }
@@ -171,7 +171,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function whereDoesntHave($relation, Closure $callback = null)
+    public function whereDoesntHave($relation, ?Closure $callback = null)
     {
         return $this->doesntHave($relation, 'and', $callback);
     }
@@ -183,7 +183,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function orWhereDoesntHave($relation, Closure $callback = null)
+    public function orWhereDoesntHave($relation, ?Closure $callback = null)
     {
         return $this->doesntHave($relation, 'or', $callback);
     }
@@ -199,7 +199,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
     {
         if (is_string($relation)) {
             $relation = $this->getRelationWithoutConstraints($relation);
@@ -278,7 +278,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function doesntHaveMorph($relation, $types, $boolean = 'and', Closure $callback = null)
+    public function doesntHaveMorph($relation, $types, $boolean = 'and', ?Closure $callback = null)
     {
         return $this->hasMorph($relation, $types, '<', 1, $boolean, $callback);
     }
@@ -305,7 +305,7 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function whereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->hasMorph($relation, $types, $operator, $count, 'and', $callback);
     }
@@ -320,7 +320,7 @@ trait QueriesRelationships
      * @param  int  $count
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function orWhereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    public function orWhereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->hasMorph($relation, $types, $operator, $count, 'or', $callback);
     }
@@ -333,7 +333,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function whereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    public function whereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
     {
         return $this->doesntHaveMorph($relation, $types, 'and', $callback);
     }
@@ -346,7 +346,7 @@ trait QueriesRelationships
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function orWhereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    public function orWhereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
     {
         return $this->doesntHaveMorph($relation, $types, 'or', $callback);
     }

--- a/src/WpStarter/Database/Eloquent/Model.php
+++ b/src/WpStarter/Database/Eloquent/Model.php
@@ -1564,7 +1564,7 @@ abstract class Model implements ModelContract, Arrayable, ArrayAccess, CanBeEsca
      * @param  array|null  $except
      * @return static
      */
-    public function replicate(array $except = null)
+    public function replicate(?array $except = null)
     {
         $defaults = [
             $this->getKeyName(),

--- a/src/WpStarter/Database/Eloquent/Relations/BelongsToMany.php
+++ b/src/WpStarter/Database/Eloquent/Relations/BelongsToMany.php
@@ -760,7 +760,7 @@ class BelongsToMany extends Relation
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Eloquent\Model|static|mixed
      */
-    public function firstOr($columns = ['*'], Closure $callback = null)
+    public function firstOr($columns = ['*'], ?Closure $callback = null)
     {
         if ($columns instanceof Closure) {
             $callback = $columns;

--- a/src/WpStarter/Database/Eloquent/Relations/HasManyThrough.php
+++ b/src/WpStarter/Database/Eloquent/Relations/HasManyThrough.php
@@ -102,7 +102,7 @@ class HasManyThrough extends Relation
      * @param  \WpStarter\Database\Eloquent\Builder|null  $query
      * @return void
      */
-    protected function performJoin(Builder $query = null)
+    protected function performJoin(?Builder $query = null)
     {
         $query = $query ?: $this->query;
 

--- a/src/WpStarter/Database/Eloquent/Relations/Relation.php
+++ b/src/WpStarter/Database/Eloquent/Relations/Relation.php
@@ -425,7 +425,7 @@ abstract class Relation
      * @param  bool  $merge
      * @return array
      */
-    public static function morphMap(array $map = null, $merge = true)
+    public static function morphMap(?array $map = null, $merge = true)
     {
         $map = static::buildMorphMapFromModels($map);
 
@@ -443,7 +443,7 @@ abstract class Relation
      * @param  string[]|null  $models
      * @return array|null
      */
-    protected static function buildMorphMapFromModels(array $models = null)
+    protected static function buildMorphMapFromModels(?array $models = null)
     {
         if (is_null($models) || Arr::isAssoc($models)) {
             return $models;

--- a/src/WpStarter/Database/Migrations/Migrator.php
+++ b/src/WpStarter/Database/Migrations/Migrator.php
@@ -80,7 +80,7 @@ class Migrator
     public function __construct(MigrationRepositoryInterface $repository,
                                 Resolver $resolver,
                                 Filesystem $files,
-                                Dispatcher $dispatcher = null)
+                                ?Dispatcher $dispatcher = null)
     {
         $this->files = $files;
         $this->events = $dispatcher;

--- a/src/WpStarter/Database/MySqlConnection.php
+++ b/src/WpStarter/Database/MySqlConnection.php
@@ -66,7 +66,7 @@ class MySqlConnection extends Connection
      * @param  callable|null  $processFactory
      * @return \WpStarter\Database\Schema\MySqlSchemaState
      */
-    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
     {
         return new MySqlSchemaState($this, $files, $processFactory);
     }

--- a/src/WpStarter/Database/PostgresConnection.php
+++ b/src/WpStarter/Database/PostgresConnection.php
@@ -82,7 +82,7 @@ class PostgresConnection extends Connection
      * @param  callable|null  $processFactory
      * @return \WpStarter\Database\Schema\PostgresSchemaState
      */
-    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
     {
         return new PostgresSchemaState($this, $files, $processFactory);
     }

--- a/src/WpStarter/Database/Query/Builder.php
+++ b/src/WpStarter/Database/Query/Builder.php
@@ -228,8 +228,8 @@ class Builder
      * @return void
      */
     public function __construct(ConnectionInterface $connection,
-                                Grammar $grammar = null,
-                                Processor $processor = null)
+                                ?Grammar $grammar = null,
+                                ?Processor $processor = null)
     {
         $this->connection = $connection;
         $this->grammar = $grammar ?: $connection->getQueryGrammar();

--- a/src/WpStarter/Database/SQLiteConnection.php
+++ b/src/WpStarter/Database/SQLiteConnection.php
@@ -80,7 +80,7 @@ class SQLiteConnection extends Connection
      *
      * @throws \RuntimeException
      */
-    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
     {
         return new SqliteSchemaState($this, $files, $processFactory);
     }

--- a/src/WpStarter/Database/Schema/Blueprint.php
+++ b/src/WpStarter/Database/Schema/Blueprint.php
@@ -86,7 +86,7 @@ class Blueprint
      * @param  string  $prefix
      * @return void
      */
-    public function __construct($table, Closure $callback = null, $prefix = '')
+    public function __construct($table, ?Closure $callback = null, $prefix = '')
     {
         $this->table = $table;
         $this->prefix = $prefix;

--- a/src/WpStarter/Database/Schema/Builder.php
+++ b/src/WpStarter/Database/Schema/Builder.php
@@ -371,7 +371,7 @@ class Builder
      * @param  \Closure|null  $callback
      * @return \WpStarter\Database\Schema\Blueprint
      */
-    protected function createBlueprint($table, Closure $callback = null)
+    protected function createBlueprint($table, ?Closure $callback = null)
     {
         $prefix = $this->connection->getConfig('prefix_indexes')
                     ? $this->connection->getConfig('prefix')

--- a/src/WpStarter/Database/Schema/SchemaState.php
+++ b/src/WpStarter/Database/Schema/SchemaState.php
@@ -51,7 +51,7 @@ abstract class SchemaState
      * @param  callable|null  $processFactory
      * @return void
      */
-    public function __construct(Connection $connection, Filesystem $files = null, callable $processFactory = null)
+    public function __construct(Connection $connection, ?Filesystem $files = null, ?callable $processFactory = null)
     {
         $this->connection = $connection;
 

--- a/src/WpStarter/Database/SqlServerConnection.php
+++ b/src/WpStarter/Database/SqlServerConnection.php
@@ -98,7 +98,7 @@ class SqlServerConnection extends Connection
      *
      * @throws \RuntimeException
      */
-    public function getSchemaState(Filesystem $files = null, callable $processFactory = null)
+    public function getSchemaState(?Filesystem $files = null, ?callable $processFactory = null)
     {
         throw new RuntimeException('Schema dumping is not supported when using SQL Server.');
     }

--- a/src/WpStarter/Events/Dispatcher.php
+++ b/src/WpStarter/Events/Dispatcher.php
@@ -62,7 +62,7 @@ class Dispatcher implements DispatcherContract
      * @param  \WpStarter\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(ContainerContract $container = null)
+    public function __construct(?ContainerContract $container = null)
     {
         $this->container = $container ?: new Container;
     }

--- a/src/WpStarter/Foundation/Bootstrap/SetRequestForConsole.php
+++ b/src/WpStarter/Foundation/Bootstrap/SetRequestForConsole.php
@@ -16,7 +16,7 @@ class SetRequestForConsole
     public function bootstrap(Application $app)
     {
         $uri = $app->make('config')->get('app.url', 'http://localhost');
-
+        $uri = (string) $uri;
         $components = parse_url($uri);
 
         $server = $_SERVER;

--- a/src/WpStarter/Foundation/Http/Exceptions/MaintenanceModeException.php
+++ b/src/WpStarter/Foundation/Http/Exceptions/MaintenanceModeException.php
@@ -43,7 +43,7 @@ class MaintenanceModeException extends ServiceUnavailableHttpException
      * @param  int  $code
      * @return void
      */
-    public function __construct($time, $retryAfter = null, $message = null, Throwable $previous = null, $code = 0)
+    public function __construct($time, $retryAfter = null, $message = null, ?Throwable $previous = null, $code = 0)
     {
         parent::__construct($retryAfter, $message, $previous, $code);
 

--- a/src/WpStarter/Foundation/Http/FormRequest.php
+++ b/src/WpStarter/Foundation/Http/FormRequest.php
@@ -196,7 +196,7 @@ class FormRequest extends Request implements ValidatesWhenResolved
      * @param  array|null  $keys
      * @return \WpStarter\Support\ValidatedInput|array
      */
-    public function safe(array $keys = null)
+    public function safe(?array $keys = null)
     {
         return is_array($keys)
                     ? $this->validator->safe()->only($keys)

--- a/src/WpStarter/Foundation/Testing/Concerns/InteractsWithContainer.php
+++ b/src/WpStarter/Foundation/Testing/Concerns/InteractsWithContainer.php
@@ -48,7 +48,7 @@ trait InteractsWithContainer
      * @param  \Closure|null  $mock
      * @return \Mockery\MockInterface
      */
-    protected function mock($abstract, Closure $mock = null)
+    protected function mock($abstract, ?Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args())));
     }
@@ -60,7 +60,7 @@ trait InteractsWithContainer
      * @param  \Closure|null  $mock
      * @return \Mockery\MockInterface
      */
-    protected function partialMock($abstract, Closure $mock = null)
+    protected function partialMock($abstract, ?Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::mock(...array_filter(func_get_args()))->makePartial());
     }
@@ -72,7 +72,7 @@ trait InteractsWithContainer
      * @param  \Closure|null  $mock
      * @return \Mockery\MockInterface
      */
-    protected function spy($abstract, Closure $mock = null)
+    protected function spy($abstract, ?Closure $mock = null)
     {
         return $this->instance($abstract, Mockery::spy(...array_filter(func_get_args())));
     }

--- a/src/WpStarter/Foundation/Validation/ValidatesRequests.php
+++ b/src/WpStarter/Foundation/Validation/ValidatesRequests.php
@@ -17,7 +17,7 @@ trait ValidatesRequests
      *
      * @throws \WpStarter\Validation\ValidationException
      */
-    public function validateWith($validator, Request $request = null)
+    public function validateWith($validator, ?Request $request = null)
     {
         $request = $request ?: ws_request();
 

--- a/src/WpStarter/Http/Client/Factory.php
+++ b/src/WpStarter/Http/Client/Factory.php
@@ -98,7 +98,7 @@ class Factory
      * @param  \WpStarter\Contracts\Events\Dispatcher|null  $dispatcher
      * @return void
      */
-    public function __construct(Dispatcher $dispatcher = null)
+    public function __construct(?Dispatcher $dispatcher = null)
     {
         $this->dispatcher = $dispatcher;
 

--- a/src/WpStarter/Http/Client/PendingRequest.php
+++ b/src/WpStarter/Http/Client/PendingRequest.php
@@ -170,7 +170,7 @@ class PendingRequest
      * @param  \WpStarter\Http\Client\Factory|null  $factory
      * @return void
      */
-    public function __construct(Factory $factory = null)
+    public function __construct(?Factory $factory = null)
     {
         $this->factory = $factory;
         $this->middleware = new Collection;

--- a/src/WpStarter/Http/Client/Pool.php
+++ b/src/WpStarter/Http/Client/Pool.php
@@ -36,7 +36,7 @@ class Pool
      * @param  \WpStarter\Http\Client\Factory|null  $factory
      * @return void
      */
-    public function __construct(Factory $factory = null)
+    public function __construct(?Factory $factory = null)
     {
         $this->factory = $factory ?: new Factory();
 

--- a/src/WpStarter/Http/Concerns/InteractsWithInput.php
+++ b/src/WpStarter/Http/Concerns/InteractsWithInput.php
@@ -120,7 +120,7 @@ trait InteractsWithInput
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenHas($key, callable $callback, callable $default = null)
+    public function whenHas($key, ?callable $callback, ?callable $default = null)
     {
         if ($this->has($key)) {
             return $callback(ws_data_get($this->all(), $key)) ?: $this;
@@ -198,7 +198,7 @@ trait InteractsWithInput
      * @param  callable|null  $default
      * @return $this|mixed
      */
-    public function whenFilled($key, callable $callback, callable $default = null)
+    public function whenFilled($key, ?callable $callback, ?callable $default = null)
     {
         if ($this->filled($key)) {
             return $callback(ws_data_get($this->all(), $key)) ?: $this;

--- a/src/WpStarter/Http/Exceptions/PostTooLargeException.php
+++ b/src/WpStarter/Http/Exceptions/PostTooLargeException.php
@@ -16,7 +16,7 @@ class PostTooLargeException extends HttpException
      * @param  int  $code
      * @return void
      */
-    public function __construct($message = null, Throwable $previous = null, array $headers = [], $code = 0)
+    public function __construct($message = null, ?Throwable $previous = null, array $headers = [], $code = 0)
     {
         parent::__construct(413, $message, $previous, $headers, $code);
     }

--- a/src/WpStarter/Http/Exceptions/ThrottleRequestsException.php
+++ b/src/WpStarter/Http/Exceptions/ThrottleRequestsException.php
@@ -16,7 +16,7 @@ class ThrottleRequestsException extends TooManyRequestsHttpException
      * @param  int  $code
      * @return void
      */
-    public function __construct($message = null, Throwable $previous = null, array $headers = [], $code = 0)
+    public function __construct($message = null, ?Throwable $previous = null, array $headers = [], $code = 0)
     {
         parent::__construct(null, $message, $previous, $code, $headers);
     }

--- a/src/WpStarter/Http/RedirectResponse.php
+++ b/src/WpStarter/Http/RedirectResponse.php
@@ -71,7 +71,7 @@ class RedirectResponse extends BaseRedirectResponse
      * @param  array|null  $input
      * @return $this
      */
-    public function withInput(array $input = null)
+    public function withInput(?array $input = null)
     {
         $this->session->flashInput($this->removeFilesFromInput(
             ! is_null($input) ? $input : $this->request->input()

--- a/src/WpStarter/Http/Request.php
+++ b/src/WpStarter/Http/Request.php
@@ -502,7 +502,7 @@ class Request extends SymfonyRequest implements Arrayable, ArrayAccess
      *
      * @return static
      */
-    public function duplicate(array $query = null, array $request = null, array $attributes = null, array $cookies = null, array $files = null, array $server = null)
+    public function duplicate(?array $query = null, ?array $request = null, ?array $attributes = null, ?array $cookies = null, ?array $files = null, ?array $server = null)
     {
         return parent::duplicate($query, $request, $attributes, $cookies, $this->filterFiles($files), $server);
     }

--- a/src/WpStarter/Log/Logger.php
+++ b/src/WpStarter/Log/Logger.php
@@ -40,7 +40,7 @@ class Logger implements LoggerInterface
      * @param  \WpStarter\Contracts\Events\Dispatcher|null  $dispatcher
      * @return void
      */
-    public function __construct(LoggerInterface $logger, Dispatcher $dispatcher = null)
+    public function __construct(LoggerInterface $logger, ?Dispatcher $dispatcher = null)
     {
         $this->logger = $logger;
         $this->dispatcher = $dispatcher;

--- a/src/WpStarter/Mail/Mailer.php
+++ b/src/WpStarter/Mail/Mailer.php
@@ -100,7 +100,7 @@ class Mailer implements MailerContract, MailQueueContract
      * @param  \WpStarter\Contracts\Events\Dispatcher|null  $events
      * @return void
      */
-    public function __construct(string $name, Factory $views, Swift_Mailer $swift, Dispatcher $events = null)
+    public function __construct(string $name, Factory $views, Swift_Mailer $swift, ?Dispatcher $events = null)
     {
         $this->name = $name;
         $this->views = $views;

--- a/src/WpStarter/Notifications/ChannelManager.php
+++ b/src/WpStarter/Notifications/ChannelManager.php
@@ -47,7 +47,7 @@ class ChannelManager extends Manager implements DispatcherContract, FactoryContr
      * @param  array|null  $channels
      * @return void
      */
-    public function sendNow($notifiables, $notification, array $channels = null)
+    public function sendNow($notifiables, $notification, ?array $channels = null)
     {
         (new NotificationSender(
             $this, $this->container->make(Bus::class), $this->container->make(Dispatcher::class), $this->locale)

--- a/src/WpStarter/Notifications/NotificationSender.php
+++ b/src/WpStarter/Notifications/NotificationSender.php
@@ -87,7 +87,7 @@ class NotificationSender
      * @param  array|null  $channels
      * @return void
      */
-    public function sendNow($notifiables, $notification, array $channels = null)
+    public function sendNow($notifiables, $notification, ?array $channels = null)
     {
         $notifiables = $this->formatNotifiables($notifiables);
 

--- a/src/WpStarter/Notifications/RoutesNotifications.php
+++ b/src/WpStarter/Notifications/RoutesNotifications.php
@@ -25,7 +25,7 @@ trait RoutesNotifications
      * @param  array|null  $channels
      * @return void
      */
-    public function notifyNow($instance, array $channels = null)
+    public function notifyNow($instance, ?array $channels = null)
     {
         ws_app(Dispatcher::class)->sendNow($this, $instance, $channels);
     }

--- a/src/WpStarter/Notifications/SendQueuedNotifications.php
+++ b/src/WpStarter/Notifications/SendQueuedNotifications.php
@@ -65,7 +65,7 @@ class SendQueuedNotifications implements ShouldQueue
      * @param  array|null  $channels
      * @return void
      */
-    public function __construct($notifiables, $notification, array $channels = null)
+    public function __construct($notifiables, $notification, ?array $channels = null)
     {
         $this->channels = $channels;
         $this->notification = $notification;

--- a/src/WpStarter/Pipeline/Hub.php
+++ b/src/WpStarter/Pipeline/Hub.php
@@ -28,7 +28,7 @@ class Hub implements HubContract
      * @param  \WpStarter\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->container = $container;
     }

--- a/src/WpStarter/Pipeline/Pipeline.php
+++ b/src/WpStarter/Pipeline/Pipeline.php
@@ -44,7 +44,7 @@ class Pipeline implements PipelineContract
      * @param  \WpStarter\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->container = $container;
     }

--- a/src/WpStarter/Queue/Capsule/Manager.php
+++ b/src/WpStarter/Queue/Capsule/Manager.php
@@ -28,7 +28,7 @@ class Manager
      * @param  \WpStarter\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Container $container = null)
+    public function __construct(?Container $container = null)
     {
         $this->setupContainer($container ?: new Container);
 

--- a/src/WpStarter/Queue/Worker.php
+++ b/src/WpStarter/Queue/Worker.php
@@ -107,7 +107,7 @@ class Worker
                                 Dispatcher $events,
                                 ExceptionHandler $exceptions,
                                 callable $isDownForMaintenance,
-                                callable $resetScope = null)
+                                ?callable $resetScope = null)
     {
         $this->events = $events;
         $this->manager = $manager;

--- a/src/WpStarter/Redis/Connections/PhpRedisConnection.php
+++ b/src/WpStarter/Redis/Connections/PhpRedisConnection.php
@@ -38,7 +38,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  array  $config
      * @return void
      */
-    public function __construct($client, callable $connector = null, array $config = [])
+    public function __construct($client, ?callable $connector = null, ?array $config = [])
     {
         $this->client = $client;
         $this->config = $config;
@@ -398,7 +398,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  callable|null  $callback
      * @return \Redis|array
      */
-    public function pipeline(callable $callback = null)
+    public function pipeline(?callable $callback = null)
     {
         $pipeline = $this->client()->pipeline();
 
@@ -413,7 +413,7 @@ class PhpRedisConnection extends Connection implements ConnectionContract
      * @param  callable|null  $callback
      * @return \Redis|array
      */
-    public function transaction(callable $callback = null)
+    public function transaction(?callable $callback = null)
     {
         $transaction = $this->client()->multi();
 

--- a/src/WpStarter/Redis/Limiters/ConcurrencyLimiterBuilder.php
+++ b/src/WpStarter/Redis/Limiters/ConcurrencyLimiterBuilder.php
@@ -105,7 +105,7 @@ class ConcurrencyLimiterBuilder
      *
      * @throws \WpStarter\Contracts\Redis\LimiterTimeoutException
      */
-    public function then(callable $callback, callable $failure = null)
+    public function then(callable $callback, ?callable $failure = null)
     {
         try {
             return (new ConcurrencyLimiter(

--- a/src/WpStarter/Redis/Limiters/DurationLimiterBuilder.php
+++ b/src/WpStarter/Redis/Limiters/DurationLimiterBuilder.php
@@ -105,7 +105,7 @@ class DurationLimiterBuilder
      *
      * @throws \WpStarter\Contracts\Redis\LimiterTimeoutException
      */
-    public function then(callable $callback, callable $failure = null)
+    public function then(callable $callback, ?callable $failure = null)
     {
         try {
             return (new DurationLimiter(

--- a/src/WpStarter/Routing/Router.php
+++ b/src/WpStarter/Routing/Router.php
@@ -128,7 +128,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  \WpStarter\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Dispatcher $events, Container $container = null)
+    public function __construct(Dispatcher $events, ?Container $container = null)
     {
         $this->events = $events;
         $this->routes = new RouteCollection;
@@ -1018,7 +1018,7 @@ class Router implements BindingRegistrar, RegistrarContract
      * @param  \Closure|null  $callback
      * @return void
      */
-    public function model($key, $class, Closure $callback = null)
+    public function model($key, $class, ?Closure $callback = null)
     {
         $this->bind($key, RouteBinding::forModel($this->container, $class, $callback));
     }

--- a/src/WpStarter/Session/DatabaseSessionHandler.php
+++ b/src/WpStarter/Session/DatabaseSessionHandler.php
@@ -59,7 +59,7 @@ class DatabaseSessionHandler implements ExistenceAwareInterface, SessionHandlerI
      * @param  \WpStarter\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(ConnectionInterface $connection, $table, $minutes, Container $container = null)
+    public function __construct(ConnectionInterface $connection, $table, $minutes, ?Container $container = null)
     {
         $this->table = $table;
         $this->minutes = $minutes;

--- a/src/WpStarter/Session/Middleware/StartSession.php
+++ b/src/WpStarter/Session/Middleware/StartSession.php
@@ -35,7 +35,7 @@ class StartSession
      * @param  callable|null  $cacheFactoryResolver
      * @return void
      */
-    public function __construct(SessionManager $manager, callable $cacheFactoryResolver = null)
+    public function __construct(SessionManager $manager, ?callable $cacheFactoryResolver = null)
     {
         $this->manager = $manager;
         $this->cacheFactoryResolver = $cacheFactoryResolver;
@@ -276,7 +276,7 @@ class StartSession
      * @param  array|null  $config
      * @return bool
      */
-    protected function sessionIsPersistent(array $config = null)
+    protected function sessionIsPersistent(?array $config = null)
     {
         $config = $config ?: $this->manager->getSessionConfig();
 

--- a/src/WpStarter/Support/Str.php
+++ b/src/WpStarter/Support/Str.php
@@ -1004,7 +1004,7 @@ class Str
      * @param  callable|null  $factory
      * @return void
      */
-    public static function createUuidsUsing(callable $factory = null)
+    public static function createUuidsUsing(?callable $factory = null)
     {
         static::$uuidFactory = $factory;
     }

--- a/src/WpStarter/Support/Testing/Fakes/NotificationFake.php
+++ b/src/WpStarter/Support/Testing/Fakes/NotificationFake.php
@@ -262,7 +262,7 @@ class NotificationFake implements NotificationDispatcher, NotificationFactory
      * @param  array|null  $channels
      * @return void
      */
-    public function sendNow($notifiables, $notification, array $channels = null)
+    public function sendNow($notifiables, $notification, ?array $channels = null)
     {
         if (! $notifiables instanceof Collection && ! is_array($notifiables)) {
             $notifiables = [$notifiables];

--- a/src/WpStarter/Support/helpers.php
+++ b/src/WpStarter/Support/helpers.php
@@ -181,7 +181,7 @@ if (! function_exists('ws_optional')) {
      * @param  callable|null  $callback
      * @return mixed
      */
-    function ws_optional($value = null, callable $callback = null)
+    function ws_optional($value = null, ?callable $callback = null)
     {
         if (is_null($callback)) {
             return new Optional($value);
@@ -372,7 +372,7 @@ if (! function_exists('ws_with')) {
      * @param  callable|null  $callback
      * @return mixed
      */
-    function ws_with($value, callable $callback = null)
+    function ws_with($value, ?callable $callback = null)
     {
         return is_null($callback) ? $value : $callback($value);
     }

--- a/src/WpStarter/Testing/AssertableJsonString.php
+++ b/src/WpStarter/Testing/AssertableJsonString.php
@@ -231,7 +231,7 @@ class AssertableJsonString implements ArrayAccess, Countable
      * @param  array|null  $responseData
      * @return $this
      */
-    public function assertStructure(array $structure = null, $responseData = null)
+    public function assertStructure(?array $structure = null, $responseData = null)
     {
         if (is_null($structure)) {
             return $this->assertSimilar($this->decoded);

--- a/src/WpStarter/Testing/Fluent/AssertableJson.php
+++ b/src/WpStarter/Testing/Fluent/AssertableJson.php
@@ -40,7 +40,7 @@ class AssertableJson implements Arrayable
      * @param  string|null  $path
      * @return void
      */
-    protected function __construct(array $props, string $path = null)
+    protected function __construct(array $props, ?string $path = null)
     {
         $this->path = $path;
         $this->props = $props;
@@ -67,7 +67,7 @@ class AssertableJson implements Arrayable
      * @param  string|null  $key
      * @return mixed
      */
-    protected function prop(string $key = null)
+    protected function prop(?string $key = null)
     {
         return Arr::get($this->props, $key);
     }

--- a/src/WpStarter/Testing/Fluent/Concerns/Debugging.php
+++ b/src/WpStarter/Testing/Fluent/Concerns/Debugging.php
@@ -10,7 +10,7 @@ trait Debugging
      * @param  string|null  $prop
      * @return $this
      */
-    public function dump(string $prop = null): self
+    public function dump(?string $prop = null): self
     {
         dump($this->prop($prop));
 
@@ -23,7 +23,7 @@ trait Debugging
      * @param  string|null  $prop
      * @return void
      */
-    public function dd(string $prop = null): void
+    public function dd(?string $prop = null): void
     {
         dd($this->prop($prop));
     }
@@ -34,5 +34,5 @@ trait Debugging
      * @param  string|null  $key
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/WpStarter/Testing/Fluent/Concerns/Has.php
+++ b/src/WpStarter/Testing/Fluent/Concerns/Has.php
@@ -15,7 +15,7 @@ trait Has
      * @param  int|null  $length
      * @return $this
      */
-    public function count($key, int $length = null): self
+    public function count($key, ?int $length = null): self
     {
         if (is_null($length)) {
             $path = $this->dotPath();
@@ -48,7 +48,7 @@ trait Has
      * @param  \Closure|null  $callback
      * @return $this
      */
-    public function has($key, $length = null, Closure $callback = null): self
+    public function has($key, $length = null, ?Closure $callback = null): self
     {
         $prop = $this->prop();
 
@@ -185,7 +185,7 @@ trait Has
      * @param  string|null  $key
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 
     /**
      * Instantiate a new "scope" at the path of the given key.

--- a/src/WpStarter/Testing/Fluent/Concerns/Interaction.php
+++ b/src/WpStarter/Testing/Fluent/Concerns/Interaction.php
@@ -63,5 +63,5 @@ trait Interaction
      * @param  string|null  $key
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/WpStarter/Testing/Fluent/Concerns/Matching.php
+++ b/src/WpStarter/Testing/Fluent/Concerns/Matching.php
@@ -181,7 +181,7 @@ trait Matching
      * @param  \Closure|null  $scope
      * @return $this
      */
-    abstract public function has(string $key, $value = null, Closure $scope = null);
+    abstract public function has(string $key, $value = null, ?Closure $scope = null);
 
     /**
      * Retrieve a prop within the current scope using "dot" notation.
@@ -189,5 +189,5 @@ trait Matching
      * @param  string|null  $key
      * @return mixed
      */
-    abstract protected function prop(string $key = null);
+    abstract protected function prop(?string $key = null);
 }

--- a/src/WpStarter/Testing/TestResponse.php
+++ b/src/WpStarter/Testing/TestResponse.php
@@ -793,7 +793,7 @@ EOF;
      * @param  array|null  $responseData
      * @return $this
      */
-    public function assertJsonStructure(array $structure = null, $responseData = null)
+    public function assertJsonStructure(?array $structure = null, $responseData = null)
     {
         $this->decodeResponseJson()->assertStructure($structure, $responseData);
 

--- a/src/WpStarter/Validation/Factory.php
+++ b/src/WpStarter/Validation/Factory.php
@@ -87,7 +87,7 @@ class Factory implements FactoryContract
      * @param  \WpStarter\Contracts\Container\Container|null  $container
      * @return void
      */
-    public function __construct(Translator $translator, Container $container = null)
+    public function __construct(Translator $translator, ?Container $container = null)
     {
         $this->container = $container;
         $this->translator = $translator;

--- a/src/WpStarter/Validation/Validator.php
+++ b/src/WpStarter/Validation/Validator.php
@@ -516,7 +516,7 @@ class Validator implements ValidatorContract
      * @param  array|null  $keys
      * @return \WpStarter\Support\ValidatedInput|array
      */
-    public function safe(array $keys = null)
+    public function safe(?array $keys = null)
     {
         return is_array($keys)
                 ? (new ValidatedInput($this->validated()))->only($keys)
@@ -1353,7 +1353,7 @@ class Validator implements ValidatorContract
      * @param  callable|null  $formatter
      * @return $this
      */
-    public function setImplicitAttributesFormatter(callable $formatter = null)
+    public function setImplicitAttributesFormatter(?callable $formatter = null)
     {
         $this->implicitAttributesFormatter = $formatter;
 

--- a/src/WpStarter/View/Engines/CompilerEngine.php
+++ b/src/WpStarter/View/Engines/CompilerEngine.php
@@ -30,7 +30,7 @@ class CompilerEngine extends PhpEngine
      * @param  \WpStarter\Filesystem\Filesystem|null  $files
      * @return void
      */
-    public function __construct(CompilerInterface $compiler, Filesystem $files = null)
+    public function __construct(CompilerInterface $compiler, ?Filesystem $files = null)
     {
         parent::__construct($files ?: new Filesystem);
 

--- a/src/WpStarter/View/FileViewFinder.php
+++ b/src/WpStarter/View/FileViewFinder.php
@@ -50,7 +50,7 @@ class FileViewFinder implements ViewFinderInterface
      * @param  array|null  $extensions
      * @return void
      */
-    public function __construct(Filesystem $files, array $paths, array $extensions = null)
+    public function __construct(Filesystem $files, array $paths, ?array $extensions = null)
     {
         $this->files = $files;
         $this->paths = array_map([$this, 'resolvePath'], $paths);

--- a/src/WpStarter/View/View.php
+++ b/src/WpStarter/View/View.php
@@ -85,7 +85,7 @@ class View implements ArrayAccess, Htmlable, ViewContract
      *
      * @throws \Throwable
      */
-    public function render(callable $callback = null)
+    public function render(?callable $callback = null)
     {
         try {
             $contents = $this->renderContents();

--- a/src/WpStarter/Wordpress/Admin/Routing/Router.php
+++ b/src/WpStarter/Wordpress/Admin/Routing/Router.php
@@ -30,7 +30,7 @@ class Router extends \WpStarter\Routing\Router
      * @param Dispatcher $events
      * @param Container|null $container
      */
-    public function __construct(Dispatcher $events, Container $container = null)
+    public function __construct(Dispatcher $events, ?Container $container = null)
     {
         parent::__construct($events, $container);
         $this->routes = new MenuCollection();

--- a/src/WpStarter/Wordpress/Application.php
+++ b/src/WpStarter/Wordpress/Application.php
@@ -11,7 +11,7 @@ class Application extends \WpStarter\Foundation\Application
      *
      * @var string
      */
-    const VERSION = '1.9.10';
+    const VERSION = '1.10.0';
     /**
      * Indicates if the application has been early bootstrapped before.
      *

--- a/src/WpStarter/Wordpress/Auth/User.php
+++ b/src/WpStarter/Wordpress/Auth/User.php
@@ -9,6 +9,7 @@ use WpStarter\Contracts\Auth\Access\Authorizable as AuthorizableContract;
 use WpStarter\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use WpStarter\Contracts\Auth\CanResetPassword as CanResetPasswordContract;
 use WpStarter\Foundation\Auth\Access\Authorizable;
+use WP_User;
 
 class User extends Model implements
     AuthenticatableContract,
@@ -16,10 +17,10 @@ class User extends Model implements
 {
     use Authenticatable, Authorizable;
     /**
-     * @param \WP_User|null $wp_user
+     * @param WP_User|null $wp_user
      * @return static|null
      */
-    public static function fromWpUser(\WP_User $wp_user = null)
+    public static function fromWpUser(?WP_User $wp_user = null)
     {
         if (!$wp_user) {
             return null;

--- a/src/WpStarter/Wordpress/Exceptions/WpErrorException.php
+++ b/src/WpStarter/Wordpress/Exceptions/WpErrorException.php
@@ -10,7 +10,7 @@ class WpErrorException extends Exception
 {
     protected $wp_error;
 
-    public function __construct(string $message = "", $code = 0, Throwable $previous = null)
+    public function __construct(string $message = "", $code = 0, ?Throwable $previous = null)
     {
         parent::__construct($message, 0, $previous);
         $this->code = $code;

--- a/src/WpStarter/Wordpress/Model/Concerns/HasGlobalScopes.php
+++ b/src/WpStarter/Wordpress/Model/Concerns/HasGlobalScopes.php
@@ -18,7 +18,7 @@ trait HasGlobalScopes
      *
      * @throws \InvalidArgumentException
      */
-    public static function addGlobalScope($scope, Closure $implementation = null)
+    public static function addGlobalScope($scope, ?Closure $implementation = null)
     {
         if (is_string($scope) && !is_null($implementation)) {
             return static::$globalScopes[static::class][$scope] = $implementation;

--- a/src/WpStarter/Wordpress/Model/Concerns/QueriesRelationships.php
+++ b/src/WpStarter/Wordpress/Model/Concerns/QueriesRelationships.php
@@ -27,7 +27,7 @@ trait QueriesRelationships
      *
      * @throws \RuntimeException
      */
-    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function has($relation, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
     {
         if (is_string($relation)) {
             if (strpos($relation, '.') !== false) {
@@ -120,7 +120,7 @@ trait QueriesRelationships
      * @param \Closure|null $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function doesntHave($relation, $boolean = 'and', Closure $callback = null)
+    public function doesntHave($relation, $boolean = 'and', ?Closure $callback = null)
     {
         return $this->has($relation, '<', 1, $boolean, $callback);
     }
@@ -145,7 +145,7 @@ trait QueriesRelationships
      * @param int $count
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function whereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'and', $callback);
     }
@@ -159,7 +159,7 @@ trait QueriesRelationships
      * @param int $count
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function orWhereHas($relation, Closure $callback = null, $operator = '>=', $count = 1)
+    public function orWhereHas($relation, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->has($relation, $operator, $count, 'or', $callback);
     }
@@ -171,7 +171,7 @@ trait QueriesRelationships
      * @param \Closure|null $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function whereDoesntHave($relation, Closure $callback = null)
+    public function whereDoesntHave($relation, ?Closure $callback = null)
     {
         return $this->doesntHave($relation, 'and', $callback);
     }
@@ -183,7 +183,7 @@ trait QueriesRelationships
      * @param \Closure|null $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function orWhereDoesntHave($relation, Closure $callback = null)
+    public function orWhereDoesntHave($relation, ?Closure $callback = null)
     {
         return $this->doesntHave($relation, 'or', $callback);
     }
@@ -199,7 +199,7 @@ trait QueriesRelationships
      * @param \Closure|null $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', Closure $callback = null)
+    public function hasMorph($relation, $types, $operator = '>=', $count = 1, $boolean = 'and', ?Closure $callback = null)
     {
         if (is_string($relation)) {
             $relation = $this->getRelationWithoutConstraints($relation);
@@ -278,7 +278,7 @@ trait QueriesRelationships
      * @param \Closure|null $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function doesntHaveMorph($relation, $types, $boolean = 'and', Closure $callback = null)
+    public function doesntHaveMorph($relation, $types, $boolean = 'and', ?Closure $callback = null)
     {
         return $this->hasMorph($relation, $types, '<', 1, $boolean, $callback);
     }
@@ -305,7 +305,7 @@ trait QueriesRelationships
      * @param int $count
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function whereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    public function whereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->hasMorph($relation, $types, $operator, $count, 'and', $callback);
     }
@@ -320,7 +320,7 @@ trait QueriesRelationships
      * @param int $count
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function orWhereHasMorph($relation, $types, Closure $callback = null, $operator = '>=', $count = 1)
+    public function orWhereHasMorph($relation, $types, ?Closure $callback = null, $operator = '>=', $count = 1)
     {
         return $this->hasMorph($relation, $types, $operator, $count, 'or', $callback);
     }
@@ -333,7 +333,7 @@ trait QueriesRelationships
      * @param \Closure|null $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function whereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    public function whereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
     {
         return $this->doesntHaveMorph($relation, $types, 'and', $callback);
     }
@@ -346,7 +346,7 @@ trait QueriesRelationships
      * @param \Closure|null $callback
      * @return \WpStarter\Database\Eloquent\Builder|static
      */
-    public function orWhereDoesntHaveMorph($relation, $types, Closure $callback = null)
+    public function orWhereDoesntHaveMorph($relation, $types, ?Closure $callback = null)
     {
         return $this->doesntHaveMorph($relation, $types, 'or', $callback);
     }

--- a/src/WpStarter/Wordpress/Routing/Router.php
+++ b/src/WpStarter/Wordpress/Routing/Router.php
@@ -19,7 +19,7 @@ class Router extends BaseRouter
      * @param Dispatcher $events
      * @param Container|null $container
      */
-    public function __construct(Dispatcher $events, Container $container = null)
+    public function __construct(Dispatcher $events, ?Container $container = null)
     {
         parent::__construct($events, $container);
         $this->routes = new RouteCollection();


### PR DESCRIPTION
Added `?Type` to function parameters that had `= null` default values but were not explicitly nullable.
This avoids deprecation warnings in PHP 8.4.